### PR TITLE
Back 40 fix이슈 목록 조회

### DIFF
--- a/backend/src/main/java/com/team6/issue_tracker/application/issue/IssueRepository.java
+++ b/backend/src/main/java/com/team6/issue_tracker/application/issue/IssueRepository.java
@@ -18,14 +18,13 @@ public interface IssueRepository extends CrudRepository<Issue, Long>, PagingAndS
 
     Integer countAllByIsDeletedAndIsOpen(Boolean isDeleted, Boolean isOpen);
 
-    @Query(value = "SELECT * " +
+    @Query(value = "SELECT i.issue_idx, i.title, i.contents, i.is_open, i.created_at, i.edited_at," +
+            "i.milestone_idx, i.writer, i.assignee, i.is_deleted " +
             "FROM issue i " +
-            "LEFT JOIN labeling il ON il.issue_idx = i.issue_idx " +
             "WHERE (:isOpen IS NULL OR i.is_open = :isOpen) " +
             "AND (:milestoneIdx IS NULL OR i.milestone_idx = :milestoneIdx) " +
             "AND (:writer IS NULL OR i.writer = :writer) " +
             "AND (:assignee IS NULL OR i.assignee = :assignee) " +
-            "AND (:labelIdx IS NULL OR il.label_idx IN (:labelIdx)) " +
             "ORDER BY i.issue_idx DESC " +
             "LIMIT :pageSize OFFSET :offset")
     List<Issue> findAllBy(@Param("isOpen") Boolean isOpen,

--- a/backend/src/main/java/com/team6/issue_tracker/application/label/LabelService.java
+++ b/backend/src/main/java/com/team6/issue_tracker/application/label/LabelService.java
@@ -1,9 +1,11 @@
 package com.team6.issue_tracker.application.label;
 
+import com.team6.issue_tracker.application.issue.domain.Labeling;
+import com.team6.issue_tracker.application.label.dto.LabelDto;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 public class LabelService {
@@ -14,9 +16,15 @@ public class LabelService {
         this.labelRepository = labelRepository;
     }
 
-    public List<Label> findAll() {
-        List<Label> labelList = new ArrayList<>();
-        labelRepository.findAllNotDeleted().forEach(labelList::add);
-        return labelList;
+    public Map<Long, LabelDto> getAllLabels() {
+        Map<Long, LabelDto> labels = new HashMap<>();
+        labelRepository.findAllNotDeleted().forEach(l -> labels.put(l.getLabelIdx(), LabelDto.of(l)));
+        return labels;
+    }
+
+    public Iterable<Label> findAllById(Collection<Labeling> values) {
+        return labelRepository.findAllById(values.stream()
+                .map(Labeling::getLabelIdx)
+                .collect(Collectors.toList()));
     }
 }

--- a/backend/src/main/java/com/team6/issue_tracker/application/member/MemberService.java
+++ b/backend/src/main/java/com/team6/issue_tracker/application/member/MemberService.java
@@ -26,10 +26,10 @@ public class MemberService {
         return memberRepository.findById(index);
     }
 
-    public List<MemberDto> findAll() {
-        List<MemberDto> memberDtos = new ArrayList<>();
+    public Map<Long, MemberDto> getAllMembers() {
+        Map<Long, MemberDto> memberDtos = new HashMap<>();
         Iterable<Member> member = memberRepository.findAll();
-        member.forEach(m -> memberDtos.add(MemberDto.from(m)));
+        member.forEach(m -> memberDtos.put(m.getMemberIdx(), MemberDto.from(m)));
         return memberDtos;
     }
 }

--- a/backend/src/main/java/com/team6/issue_tracker/application/member/MemberService.java
+++ b/backend/src/main/java/com/team6/issue_tracker/application/member/MemberService.java
@@ -2,13 +2,9 @@ package com.team6.issue_tracker.application.member;
 
 import com.team6.issue_tracker.application.member.domain.Member;
 import com.team6.issue_tracker.application.member.dto.MemberDto;
-import lombok.AllArgsConstructor;
-import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 @Service
 public class MemberService {
@@ -22,8 +18,8 @@ public class MemberService {
         memberRepository.save(member);
     }
 
-    public Optional<Member> findById(Long index) {
-        return memberRepository.findById(index);
+    public Member findById(Long index) {
+        return memberRepository.findById(index).orElseThrow();
     }
 
     public Map<Long, MemberDto> getAllMembers() {

--- a/backend/src/main/java/com/team6/issue_tracker/application/milestone/MilestoneService.java
+++ b/backend/src/main/java/com/team6/issue_tracker/application/milestone/MilestoneService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 
 @Service
 @RequiredArgsConstructor
@@ -20,5 +21,14 @@ public class MilestoneService {
         milestones.forEach(m -> milestoneMap.put(m.getMilestoneIdx(), m));
         return milestoneMap;
     }
+
+    public Milestone findById(Long id) throws NoSuchElementException {
+        Milestone milestone = milestoneRepository.findById(id).orElseThrow();
+
+        if (milestone.getIsDeleted()) {
+            throw new NoSuchElementException("삭제된 마일스톤입니다.");
+        }
+
+        return milestone;
     }
 }

--- a/backend/src/main/java/com/team6/issue_tracker/application/milestone/MilestoneService.java
+++ b/backend/src/main/java/com/team6/issue_tracker/application/milestone/MilestoneService.java
@@ -13,7 +13,12 @@ public class MilestoneService {
 
     private final MilestoneRepository milestoneRepository;
 
-    public List<Milestone> findAll() {
-        return milestoneRepository.findAllByIsDeletedFalse();
+    public Map<Long, Milestone> getAllMilestones() {
+        List<Milestone> milestones = milestoneRepository.findAllByIsDeletedFalse();
+
+        Map<Long, Milestone> milestoneMap = new HashMap<>();
+        milestones.forEach(m -> milestoneMap.put(m.getMilestoneIdx(), m));
+        return milestoneMap;
+    }
     }
 }

--- a/backend/src/main/java/com/team6/issue_tracker/application/page/PageController.java
+++ b/backend/src/main/java/com/team6/issue_tracker/application/page/PageController.java
@@ -1,60 +1,24 @@
 package com.team6.issue_tracker.application.page;
 
-import com.team6.issue_tracker.application.issue.IssueService;
-import com.team6.issue_tracker.application.issue.dto.IssueDto;
-import com.team6.issue_tracker.application.milestone.Milestone;
-import com.team6.issue_tracker.application.milestone.MilestoneService;
 import com.team6.issue_tracker.application.page.dto.IssuePageRequest;
 import com.team6.issue_tracker.application.page.dto.IssuePageResponse;
-import com.team6.issue_tracker.application.label.LabelService;
-import com.team6.issue_tracker.application.member.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
-
 @RestController
+@RequiredArgsConstructor
 public class PageController {
 
     private final PageService pageService;
-    private final IssueService issueService;
-    private final MemberService memberService;
-    private final LabelService labelService;
-    private final MilestoneService milestoneService;
-
-    public PageController(PageService pageService,
-                          IssueService issueService,
-                          MemberService memberService,
-                          LabelService labelService,
-                          MilestoneService milestoneService) {
-        this.pageService = pageService;
-        this.issueService = issueService;
-        this.memberService = memberService;
-        this.labelService = labelService;
-        this.milestoneService = milestoneService;
-    }
 
     @Operation(
-            summary = "",
-            tags = "issue",
+            summary = "이슈 목록",
+            tags = "issue page",
             description = "사용자는 이슈 목록을 필터링하여 볼 수 있다."
     )
     @GetMapping("/issue")
     public IssuePageResponse findAllIssueOpenList(IssuePageRequest requestParams) {
-
-        List<IssueDto> issueList = pageService.findAllByfilter(requestParams.getPage(), requestParams.toFilter());
-
-        return IssuePageResponse.builder()
-                .issuesList(issueList)
-                .openIssueCount(issueService.getOpenIssueNum())
-                .closedIssueCount(issueService.getClosedIssueNum())
-                .page(requestParams.getPage())
-                .maxPage(pageService.getOpenIssueMaxPage())
-                .userList(memberService.findAll())
-                .labelList(labelService.findAll())
-                .milestoneList(new ArrayList<>(pageService.getAllMilestone().values()))
-                .build();
+        return pageService.getAPage(requestParams.getPage(), requestParams.toFilter());
     }
 }

--- a/backend/src/main/java/com/team6/issue_tracker/application/page/dto/IssueDto.java
+++ b/backend/src/main/java/com/team6/issue_tracker/application/page/dto/IssueDto.java
@@ -1,4 +1,4 @@
-package com.team6.issue_tracker.application.issue.dto;
+package com.team6.issue_tracker.application.page.dto;
 
 import com.team6.issue_tracker.application.label.dto.LabelDto;
 import com.team6.issue_tracker.application.member.dto.MemberDto;

--- a/backend/src/main/java/com/team6/issue_tracker/application/page/dto/IssuePageResponse.java
+++ b/backend/src/main/java/com/team6/issue_tracker/application/page/dto/IssuePageResponse.java
@@ -1,7 +1,6 @@
 package com.team6.issue_tracker.application.page.dto;
 
-import com.team6.issue_tracker.application.issue.dto.IssueDto;
-import com.team6.issue_tracker.application.label.Label;
+import com.team6.issue_tracker.application.label.dto.LabelDto;
 import com.team6.issue_tracker.application.member.dto.MemberDto;
 import com.team6.issue_tracker.application.milestone.Milestone;
 import lombok.Builder;
@@ -17,7 +16,7 @@ public class IssuePageResponse {
     private Integer openIssueMaxPage;
     private Integer closeIssueMaxPage;
     private List<IssueDto> issuesList;
-    private List<Label> labelList;
+    private List<LabelDto> labelList;
     private List<Milestone> milestoneList;
     private List<MemberDto> userList;
 

--- a/backend/src/main/java/com/team6/issue_tracker/application/page/dto/IssuePageResponse.java
+++ b/backend/src/main/java/com/team6/issue_tracker/application/page/dto/IssuePageResponse.java
@@ -14,7 +14,8 @@ public class IssuePageResponse {
     private Integer openIssueCount;
     private Integer closedIssueCount;
     private Integer page;
-    private Integer maxPage;
+    private Integer openIssueMaxPage;
+    private Integer closeIssueMaxPage;
     private List<IssueDto> issuesList;
     private List<Label> labelList;
     private List<Milestone> milestoneList;


### PR DESCRIPTION
## 수정한 사항
- n+1쿼리가 계속 발생하는 로직이라 마음에 걸렸는데... 어차피 모든 엔티티를 조회하는 요청을 하기 때문에 로직을 간단하게 변경하였습니다.
- 모두 불러와서 Map으로 저장해두고 ID에 맞는 값을 찾아 주입하는 로직입니다.

- domain service (issue, member, label 등..)를 application service(여기서는 page service)에서 참조하는 계층 구조를 생각하였습니다. 반대 방향의 참조는 당연하지만 안됩니다.
- service에서 연관관계를 맺으면서 자연스럽게 controller 에서 연관관계를 삭제하였습니다.

- 하면서 패키지 구조가 고민이 되는데... 월요일에 같이 얘기해봐요